### PR TITLE
Cursor pointer fix

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -63,3 +63,7 @@
   font-style: normal;
   font-variation-settings: 'wdth' 70;
 }
+
+.pointer {
+  cursor: pointer;
+}

--- a/src/components/SubcategoryCard.vue
+++ b/src/components/SubcategoryCard.vue
@@ -14,7 +14,7 @@ const props = defineProps<{
 
 <template>
   <BCard
-    class="border-2"
+    class="border-2 pointer"
     @mouseover="hover = true"
     @mouseleave="hover = press = false"
     @mousedown="press = true"


### PR DESCRIPTION
Resolves #27

For main category card this was not required because we're using RouterLink for navigating there. But for SubCategoryCard I had to add a new class for cursor:pointer, because there is no class for this in bootstrap.