### PR TITLE
Add universal search bar on home page

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -20,6 +20,7 @@ declare module 'vue' {
     ReloadPrompt: typeof import('./src/components/ReloadPrompt.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
+    SearchBar: typeof import('./src/components/SearchBar.vue')['default']
     SubcategoryCard: typeof import('./src/components/SubcategoryCard.vue')['default']
     WordCard: typeof import('./src/components/WordCard.vue')['default']
   }

--- a/src/components/CategoryCard.vue
+++ b/src/components/CategoryCard.vue
@@ -6,6 +6,7 @@ import { ref } from 'vue'
 
 const props = defineProps<{
   category: Category
+  searchInput: string
 }>()
 
 const hover = ref(false)
@@ -26,6 +27,7 @@ const press = ref(false)
         'border-primary': press,
         'shadow-sm': press,
       }"
+      v-if="!searchInput || category.name.toLowerCase().includes(searchInput.toLowerCase())"
     >
       <LucideIcon
         :name="category.icon"

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -12,7 +12,7 @@ const handleInput = (event: Event) => {
 </script>
 
 <template>
-  <div>
+  <div class="search-bar-container">
     <input
       type="text"
       v-model="searchInput"

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import { ref, defineEmits } from 'vue'
+
+const searchInput = ref('')
+const emit = defineEmits(['update:searchInput'])
+
+const handleInput = (event: Event) => {
+  const target = event.target as HTMLInputElement
+  searchInput.value = target.value
+  emit('update:searchInput', searchInput.value)
+}
+</script>
+
+<template>
+  <div>
+    <input
+      type="text"
+      v-model="searchInput"
+      @input="handleInput"
+      placeholder="Search..."
+      class="form-control"
+    />
+  </div>
+</template>

--- a/src/components/WordCard.vue
+++ b/src/components/WordCard.vue
@@ -6,6 +6,7 @@ import { Volume2, AudioLines } from 'lucide-vue-next'
 const props = defineProps<{
   word: string
   translation: Translation
+  searchInput: string
 }>()
 
 const langStore = useLangStore()
@@ -21,7 +22,7 @@ const pronounce = () => {
 </script>
 
 <template>
-  <BCard class="my-3">
+  <BCard class="my-3" v-if="!searchInput || word.toLowerCase().includes(searchInput.toLowerCase())">
     <BCardBody class="p-2">
       <div class="row align-items-center">
         <div class="col me-auto">

--- a/src/views/CategoryView.vue
+++ b/src/views/CategoryView.vue
@@ -68,6 +68,7 @@ wordlist.value = getWordListForLang(langStore.lang)
         :word="word"
         :translation="wordlist!![word]"
         :key="word"
+        :searchInput="searchInput"
       />
     </section>
   </div>

--- a/src/views/CategoryView.vue
+++ b/src/views/CategoryView.vue
@@ -21,6 +21,7 @@ const subcategory = computed(() =>
 )
 const langStore = useLangStore()
 const wordlist = ref<TranslatedWords | null>(null)
+const searchInput = ref('')
 
 function selectSubCategory(subcategory: string) {
   selectedSubcategory.value = subcategory
@@ -58,6 +59,7 @@ wordlist.value = getWordListForLang(langStore.lang)
             'border-2': subcat.name === selectedSubcategory,
             shadow: subcat.name !== selectedSubcategory,
           }"
+          :searchInput="searchInput"
         />
       </div>
     </section>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -2,6 +2,32 @@
 import CategoryCard from '@/components/CategoryCard.vue'
 import { Globe } from 'lucide-vue-next'
 import { WordCategories } from '@/data/categories'
+import { ref, computed } from 'vue'
+import SearchBar from '@/components/SearchBar.vue'
+import WordCard from '@/components/WordCard.vue'
+import { getWordListForLang, type TranslatedWords } from '@/data/words'
+import { useLangStore } from '@/stores/lang'
+
+const searchInput = ref('')
+const langStore = useLangStore()
+const wordlist = ref<TranslatedWords | null>(null)
+
+const filteredWords = computed(() => {
+  if (searchInput.value.length < 2) {
+    return []
+  }
+  wordlist.value = getWordListForLang(langStore.lang)
+  return Object.keys(wordlist.value).filter(word =>
+    word.toLowerCase().includes(searchInput.value.toLowerCase())
+  )
+})
+
+const filteredCategories = computed(() => {
+  if (searchInput.value.length < 2) {
+    return WordCategories
+  }
+  return []
+})
 </script>
 
 <template>
@@ -14,12 +40,21 @@ import { WordCategories } from '@/data/categories'
       <div class="text-center">select the language of the destination you are travelling to</div>
       <div class="text-center">then pick a category to discover essential words and phrases</div>
     </header>
+    <SearchBar v-model="searchInput" />
     <section class="container mt-4">
       <div class="row row-cols-2 row-cols-md-3 row-cols-lg-3 row-cols-xl-5 g-4">
         <CategoryCard
-          v-for="category of WordCategories"
+          v-for="category of filteredCategories"
           :category="category"
           :key="category.name"
+        />
+      </div>
+      <div class="row row-cols-2 row-cols-md-3 row-cols-lg-3 row-cols-xl-5 g-4">
+        <WordCard
+          v-for="word in filteredWords"
+          :word="word"
+          :translation="wordlist!![word]"
+          :key="word"
         />
       </div>
     </section>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -40,7 +40,7 @@ const filteredCategories = computed(() => {
       <div class="text-center">select the language of the destination you are travelling to</div>
       <div class="text-center">then pick a category to discover essential words and phrases</div>
     </header>
-    <SearchBar v-model="searchInput" />
+    <SearchBar v-model="searchInput" class="search-bar-container" />
     <section class="container mt-4">
       <div class="row row-cols-2 row-cols-md-3 row-cols-lg-3 row-cols-xl-5 g-4">
         <CategoryCard
@@ -60,3 +60,10 @@ const filteredCategories = computed(() => {
     </section>
   </main>
 </template>
+
+<style scoped>
+.search-bar-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+</style>


### PR DESCRIPTION
Add a universal search bar to the home page with typeahead functionality.

* **HomeView.vue**
  - Import necessary components and functions.
  - Add a search bar component at the top of the template.
  - Bind the search input to a data property using `v-model`.
  - Add computed properties to filter words and categories based on the search input.
  - Conditionally render word cards and category cards based on the search input.

* **SearchBar.vue**
  - Create a new Vue component for the search bar.
  - Add an input field with a `v-model` directive to bind the search input to a data property.
  - Add a method to handle the input event and emit the search input value to the parent component.

* **CategoryCard.vue**
  - Add a `v-if` directive to conditionally render the category cards based on the search input.

* **WordCard.vue**
  - Add a `v-if` directive to conditionally render the word cards based on the search input.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/championswimmer/localise.travel/pull/29?shareId=a7ae0bff-8288-49f7-973e-146da1defe1f).