### PR TITLE
Add universal search bar in home page

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -22,5 +22,6 @@ declare module 'vue' {
     RouterView: typeof import('vue-router')['RouterView']
     SubcategoryCard: typeof import('./src/components/SubcategoryCard.vue')['default']
     WordCard: typeof import('./src/components/WordCard.vue')['default']
+    SearchBar: typeof import('./src/components/SearchBar.vue')['default']
   }
 }

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -1,0 +1,28 @@
+<template>
+  <div>
+    <input
+      type="text"
+      v-model="searchQuery"
+      @input="onInput"
+      placeholder="Search..."
+      class="form-control"
+    />
+    <button @click="clearInput" class="btn btn-secondary mt-2">Clear</button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, defineEmits } from 'vue'
+
+const searchQuery = ref('')
+const emit = defineEmits(['search'])
+
+const onInput = () => {
+  emit('search', searchQuery.value)
+}
+
+const clearInput = () => {
+  searchQuery.value = ''
+  emit('search', searchQuery.value)
+}
+</script>

--- a/src/data/words/index.ts
+++ b/src/data/words/index.ts
@@ -56,3 +56,8 @@ export const getWordListForLang = (lang: LangCode): TranslatedWords => {
       return frenchWordList
   }
 }
+
+export const searchWordsInLang = (lang: LangCode, query: string): string[] => {
+  const wordList = getWordListForLang(lang)
+  return Object.keys(wordList).filter((word) => word.includes(query.toLowerCase()))
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -10,7 +10,7 @@ import { useLangStore } from '@/stores/lang'
 
 const langStore = useLangStore()
 const searchQuery = ref('')
-const searchResults = ref([])
+const searchResults = ref<string[]>([])
 
 const handleSearch = (query: string) => {
   searchQuery.value = query

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -2,6 +2,27 @@
 import CategoryCard from '@/components/CategoryCard.vue'
 import { Globe } from 'lucide-vue-next'
 import { WordCategories } from '@/data/categories'
+import SearchBar from '@/components/SearchBar.vue'
+import { ref } from 'vue'
+import { getWordListForLang } from '@/data/words'
+import WordCard from '@/components/WordCard.vue'
+import { useLangStore } from '@/stores/lang'
+
+const langStore = useLangStore()
+const searchQuery = ref('')
+const searchResults = ref([])
+
+const handleSearch = (query: string) => {
+  searchQuery.value = query
+  if (query.length >= 2) {
+    const wordList = getWordListForLang(langStore.lang)
+    searchResults.value = Object.keys(wordList).filter((word) =>
+      word.includes(query.toLowerCase())
+    )
+  } else {
+    searchResults.value = []
+  }
+}
 </script>
 
 <template>
@@ -15,11 +36,20 @@ import { WordCategories } from '@/data/categories'
       <div class="text-center">then pick a category to discover essential words and phrases</div>
     </header>
     <section class="container mt-4">
-      <div class="row row-cols-2 row-cols-md-3 row-cols-lg-3 row-cols-xl-5 g-4">
+      <SearchBar @search="handleSearch" />
+      <div v-if="searchQuery.length < 2" class="row row-cols-2 row-cols-md-3 row-cols-lg-3 row-cols-xl-5 g-4">
         <CategoryCard
           v-for="category of WordCategories"
           :category="category"
           :key="category.name"
+        />
+      </div>
+      <div v-else class="row row-cols-2 row-cols-md-3 row-cols-lg-3 row-cols-xl-5 g-4">
+        <WordCard
+          v-for="word in searchResults"
+          :word="word"
+          :translation="getWordListForLang(langStore.lang)[word]"
+          :key="word"
         />
       </div>
     </section>


### PR DESCRIPTION
Add a universal search bar in the home page to enable typeahead search and display word cards based on search results.

* **HomeView.vue**
  - Import `SearchBar` component, `ref` from Vue, `getWordListForLang` from words data, `WordCard` component, and `useLangStore` from stores.
  - Define `langStore`, `searchQuery`, and `searchResults` variables.
  - Implement `handleSearch` function to update `searchQuery` and filter word list based on the query.
  - Add `SearchBar` component inside the container with category cards.
  - Conditionally render category cards or word cards based on the length of `searchQuery`.

* **index.ts**
  - Add `searchWordsInLang` function to search words in the current language based on the query.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/championswimmer/localise.travel/pull/30?shareId=6e5543c1-6b15-457d-bb58-dd16c07ab8ed).